### PR TITLE
Add Devcontainer support for the repository

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,14 @@
+# Glupe Dev Container
+# Dependencies: g++ (C++17), make, curl
+# Ollama runs on the host; container connects via host.docker.internal
+FROM mcr.microsoft.com/devcontainers/cpp:1-ubuntu-24.04
+
+# Install build-essential (g++, make), curl
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    curl \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Glupe is built in postCreateCommand (workspace is mounted later)
+USER vscode

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,36 @@
+# Glupe Dev Container
+
+This devcontainer builds Glupe and connects to **Ollama running on your host machine** (no Ollama inside the container).
+
+## Host setup (required for `-local` mode)
+
+Ollama must listen on all interfaces so the container can reach it:
+
+**macOS:**
+```bash
+launchctl setenv OLLAMA_HOST "0.0.0.0:11434"
+```
+Then restart the Ollama app.
+
+**Linux:**
+```bash
+sudo systemctl edit ollama.service
+```
+Add under `[Service]`:
+```ini
+Environment="OLLAMA_HOST=0.0.0.0:11434"
+```
+Then:
+```bash
+sudo systemctl daemon-reload && sudo systemctl restart ollama
+```
+
+**Windows:** Set `OLLAMA_HOST=0.0.0.0:11434` in Environment Variables, then restart Ollama.
+
+## Usage
+
+1. Start Ollama on the host and pull a model: `ollama pull qwen2.5-coder:3b`
+2. Reopen the project in the devcontainer
+3. Run: `glupe hello.glp -o hello.exe -cpp -local`
+
+Glupe is built to `build/glupe` (keeps workspace root clean on the host volume). To rebuild: run task **Rebuild Glupe (devcontainer)** or `.devcontainer/build.sh`.

--- a/.devcontainer/build.sh
+++ b/.devcontainer/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Build Glupe to build/ (devcontainer only). Keeps workspace root clean on host.
+# GLUPE_OUT is set in devcontainer.json so make outputs to build/glupe.
+set -e
+cd "$(dirname "$0")/.."
+mkdir -p build
+sudo chown vscode:vscode build
+make
+
+# Make glupe available globally via ~/.local/bin
+mkdir -p ~/.local/bin
+cp "$(pwd)/build/glupe" ~/.local/bin/glupe
+grep -q '\.local/bin' ~/.bashrc || echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+{
+  "name": "Glupe Dev",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "runArgs": [
+    "--add-host=host.docker.internal:host-gateway"
+  ],
+  "mounts": [
+    "source=glupe-build,target=${containerWorkspaceFolder}/build,type=volume"
+  ],
+  "containerEnv": {
+    "GLUPE_OUT": "build/glupe"
+  },
+  "postCreateCommand": "chmod +x .devcontainer/build.sh .devcontainer/post-build.sh && .devcontainer/build.sh && .devcontainer/post-build.sh",
+  "postStartCommand": "echo 'Glupe built. Use: glupe --help'",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-vscode.cpptools",
+        "ms-vscode.cmake-tools"
+      ],
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash"
+      }
+    }
+  },
+  "features": {},
+  "remoteUser": "vscode"
+}

--- a/.devcontainer/post-build.sh
+++ b/.devcontainer/post-build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Post-build setup: init config if needed, set Ollama URL for host.
+set -e
+cd "$(dirname "$0")/.."
+
+./build/glupe config url-local 'http://host.docker.internal:11434/api/generate'

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 # --- Binaries and Executables ---
+glupe
+build/
 *.exe
 *.dll
 *.o
@@ -15,7 +17,8 @@ critics_and_improvement/
 config.json
 build.bat
 # ---  IDE ---
-.vscode/
+.vscode/*
+!.vscode/tasks.json
 .idea/
 __pycache__/
 

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Devcontainer: Rebuild Glupe",
+      "type": "shell",
+      "command": "${workspaceFolder}/.devcontainer/build.sh",
+      "group": "build",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared"
+      }
+    }
+  ]
+}

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,5 @@
+# GLUPE_OUT: output path. Default: glupe (local). In devcontainer: build/glupe
+OUT ?= $(or $(GLUPE_OUT),glupe)
+
 glupe:
-	g++ glupec.cpp -o glupe -std=c++17 -lstdc++fs -static-libgcc -static-libstdc++
+	g++ glupec.cpp -o $(OUT) -std=c++17 -lstdc++fs -static-libgcc -static-libstdc++


### PR DESCRIPTION
1. Added a dedicated devcontainer configuration with dockerfile and scripts.
2. Customized make to allow custom out directory for build artifacts.
3. Added VSCode Task to rebuild Glupe and relink it as a global package in a container. (do we want to keep files like this in repo? Otherwise we have to instruct user how to rebuild properly.

By default, Devcontainer assumes Ollama as an LLM provider hosted on the same machine.